### PR TITLE
Close the socket properly

### DIFF
--- a/cjdnsmap.py
+++ b/cjdnsmap.py
@@ -209,6 +209,7 @@ while True:
     data += r
     if not r or r.endswith('....e\n'):
         break
+s.shutdown(socket.SHUT_RDWR)
 s.close()
 data = data.strip()
 bencode = decode(data)


### PR DESCRIPTION
The socket opened to the admin control thing (localhost:11234) is not closed properly which was leading to all kinds of trouble. Apparently [socket.close()](http://docs.python.org/library/socket.html#socket.socket.close) doesn't close the socket. That's [socket.shutdown()](http://docs.python.org/library/socket.html#socket.socket.shutdown). Also: First pull request i've ever done, so I most likely did something wrong.
